### PR TITLE
Add AppVeyor and Travis badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # mypy_mypyc-wheels
 Automated building and storage of mypyc-compiled mypy binaries
+
+https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels
+
+https://travis-ci.org/mypyc/mypy_mypyc-wheels

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mypy_mypyc-wheels
 Automated building and storage of mypyc-compiled mypy binaries
 
-[![AppVeyor build](https://ci.appveyor.com/api/projects/status/4mew1a93xdkbf5ua/branch/master?svg=true)](https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels)
-[![Travis-CI build](https://api.travis-ci.org/python/mypy.svg?branch=master)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)
+- AppVeyor:
+  [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/4mew1a93xdkbf5ua/branch/master?svg=true)](https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels)
+- Travis-CI:
+  [![Travis-CI build status](https://api.travis-ci.org/python/mypy.svg?branch=master)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Automated building and storage of mypyc-compiled mypy binaries
 - AppVeyor:
   [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/mypyc/mypy_mypyc-wheels?svg=true)](https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels)
 - Travis-CI:
-  [![Travis-CI build status](https://api.travis-ci.org/mypyc/mypy_mypyc-wheels.svg?branch=master)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)
+  [![Travis-CI build status](https://api.travis-ci.org/mypyc/mypy_mypyc-wheels.svg)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Automated building and storage of mypyc-compiled mypy binaries
 
 - AppVeyor:
-  [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/4mew1a93xdkbf5ua/branch/master?svg=true)](https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels)
+  [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/mypyc/mypy_mypyc-wheels?svg=true)](https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels)
 - Travis-CI:
-  [![Travis-CI build status](https://api.travis-ci.org/python/mypy.svg?branch=master)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)
+  [![Travis-CI build status](https://api.travis-ci.org/mypyc/mypy_mypyc-wheels.svg?branch=master)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # mypy_mypyc-wheels
 Automated building and storage of mypyc-compiled mypy binaries
 
-https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels
-
-https://travis-ci.org/mypyc/mypy_mypyc-wheels
+[![AppVeyor build](https://ci.appveyor.com/api/projects/status/4mew1a93xdkbf5ua/branch/master?svg=true)](https://ci.appveyor.com/project/mypyc/mypy-mypyc-wheels)
+[![Travis-CI build](https://api.travis-ci.org/python/mypy.svg?branch=master)](https://travis-ci.org/mypyc/mypy_mypyc-wheels)


### PR DESCRIPTION
So I can check the status of the build jobs without having to remember where they live.