### PR TITLE
ci: add CPython 3.8 Apple Silicon wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.7"
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.9
+          python -m pip install "cibuildwheel~=1.12.0"
       - name: Checkout mypy
         shell: bash
         # use a commit hash checked into a file to get the mypy revision to build.


### PR DESCRIPTION
Ignore the commit message, this adds 3.8 Apple Silicon wheels, not 3.9 (which were already there).