### PR TITLE
Use the default MSVC config for Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,6 @@ jobs:
       - name: Build wheels
         run: |
           python mypy/misc/build_wheel.py --output-dir wheelhouse --python-version ${{ matrix.python-version}}
-        if: matrix.os != 'windows-latest'
-      - name: Build wheels (Windows)
-        env:
-          CIBW_ARCHS_WINDOWS: "AMD64"
-        shell: cmd
-        # IMPORTANT: Without a 64-bit compiler, we may run out of memory during the build
-        run: >
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" &&
-          set DISTUTILS_USE_SDK=1 &&
-          python mypy/misc/build_wheel.py --output-dir wheelhouse --python-version ${{ matrix.python-version}}
-        if: matrix.os == 'windows-latest'
       - uses: actions/upload-artifact@v2
         with:
           name: dist


### PR DESCRIPTION
Attempt to fix Windows wheel builds (python/mypy#12245).