### PR TITLE
Update cibuildwheel to support musllinux wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: "3.7"
+          python-version: "3.9"
       - name: Install cibuildwheel
         run: |
-          python -m pip install "cibuildwheel==2.1.3"
+          python -m pip install "cibuildwheel==2.8.1"
       - name: Checkout mypy
         shell: bash
         # use a commit hash checked into a file to get the mypy revision to build.
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: "3.7"
+          python-version: "3.9"
       - name: Checkout mypy
         shell: bash
         run: |


### PR DESCRIPTION
This will also update manylinux image to `manylinux2014`, from the EOL `manylinux2010`.

See linked `mypy` PR as they need to be merged together.