### PR TITLE
Use pypa/build instead of pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Build sdist and wheel
         run: |
           cd mypy
-          pip install --upgrade setuptools pip wheel
-          python setup.py sdist bdist_wheel
+          pip install --upgrade setuptools build
+          python -m build
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,5 +1,7 @@
 [tool.cibuildwheel]
 
+build-frontend = "build"
+
 # Don't build 32-bit wheels
 skip = [
   "*-manylinux_i686",


### PR DESCRIPTION
This option is documented here: https://cibuildwheel.readthedocs.io/en/stable/options/#build-frontend

There is a note that
> Until v2.0.0, `pip` was the only way to build wheels, and is still the default. However, we expect that at some point in the future, cibuildwheel will change the default to `build`, in line with the PyPA's recommendation. If you want to try `build` before this, you can use this option.

so it seems that trying this out anyway is a good idea.

Opening as a draft because I want to see if it is any faster before proposing it outright.