### PR TITLE
update links to basedmypy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         # submodules prove problematic since .git is outside cibuildwheel's manylinux container
         run: |
           COMMIT=$(cat mypy_commit)
-          git clone https://github.com/python/mypy.git
+          git clone https://github.com/KotlinIsland/mypy.git
           cd mypy
           git checkout $COMMIT
           git submodule update --init --recursive
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           COMMIT=$(cat mypy_commit)
-          git clone https://github.com/python/mypy.git
+          git clone https://github.com/KotlinIsland/mypy.git
           cd mypy
           git checkout $COMMIT
           git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ If wheels aren't getting built, debug over at
 https://github.com/mypyc/mypy_mypyc-wheels/actions
 
 You can use pip to install these wheels like so:
-```
-pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases/tag/v0.920+dev.48181d26e7575aece8cab61eb866ac6c573dfd76 mypy
-# or possibly
-pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases/latest mypy
+```bash
+pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases mypy
+# or if you need a specific version
+pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases mypy==0.990+dev.4ccfca162184ddbc9139f7a3abd72ce7139a2ec3
 ```
 
 ##  Building locally

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ https://github.com/mypyc/mypy_mypyc-wheels/actions
 
 You can use pip to install these wheels like so:
 ```bash
-pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases mypy
+pip install --upgrade --find-links https://github.com/KotlinIsland/mypy_mypyc-wheels/releases basedmypy
 # or if you need a specific version
-pip install --upgrade --find-links https://github.com/mypyc/mypy_mypyc-wheels/releases mypy==0.990+dev.4ccfca162184ddbc9139f7a3abd72ce7139a2ec3
+pip install --upgrade --find-links https://github.com/KotlinIsland/mypy_mypyc-wheels/releases basedmypy==1.6.0+dev.8e2443a74c9fb1726dc2c730b5e469881d3c1acf
 ```
 
 ##  Building locally


### PR DESCRIPTION
The links in the readme were correct before, but there was a change upstream