### PR TITLE
Add cache to `actions/setup-python`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         name: Install Python
         with:
           python-version: "3.9"
+          cache: 'pip'
       - name: Checkout mypy
         shell: bash
         run: |
@@ -115,6 +116,7 @@ jobs:
         name: Install Python
         with:
           python-version: "3.10"
+          cache: 'pip'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.5.0 # pyodide tests with this version


### PR DESCRIPTION
**Problem**

We're downloading the same Python packages repeatedly, which adds time to each build.

**Solution**

Use the GitHub Actions cache integration that ships with `actions/setup-python` to avoid downloading the same package versions repeatedly. If any package versions are updated in the registry, the fresh packages will be used rather than the cached ones.