### PR TITLE
Upgrade to `cibuildwheel@2.16.1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           git -C mypy checkout $(cat mypy_commit)
       - name: Install cibuildwheel and pypyp
         run: |
-          pipx install cibuildwheel==2.15.0
+          pipx install cibuildwheel==2.16.1
           pipx install pypyp==1
       - id: set-matrix
         run: |
@@ -62,7 +62,7 @@ jobs:
           git clone https://github.com/python/mypy.git --recurse-submodules
           git -C mypy checkout $(cat mypy_commit)
 
-      - uses: pypa/cibuildwheel@v2.15.0
+      - uses: pypa/cibuildwheel@v2.16.1
         with:
           config-file: cibuildwheel.toml
           package-dir: mypy


### PR DESCRIPTION
**Problem**

We're on a slightly outdated version of cibuildwheel.

**Solution**

Upgrade to the latest version, which has a few minor bugfixes (unsure whether they're even relevant) and now builds against 3.12.0rc3.