### PR TITLE
Invoke pytest once instead of twice

### DIFF
--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -37,10 +37,9 @@ test-command = """ \
      && cp '{project}/mypy/pyproject.toml' '{project}/mypy/conftest.py' $DIR \
 \
      && MYPY_TEST_DIR=$(python -c 'import mypy.test; print(mypy.test.__path__[0])') \
-     && MYPY_TEST_PREFIX='{project}/mypy' pytest $MYPY_TEST_DIR \
-\
      && MYPYC_TEST_DIR=$(python -c 'import mypyc.test; print(mypyc.test.__path__[0])') \
-     && MYPY_TEST_PREFIX='{project}/mypy' pytest $MYPYC_TEST_DIR -k 'not test_external' \
+\
+     && MYPY_TEST_PREFIX='{project}/mypy' pytest $MYPY_TEST_DIR $MYPYC_TEST_DIR -k 'not test_external' \
    )
 """
 


### PR DESCRIPTION
**Problem**

We're invoking pytest twice, which ends up being slightly slower because there's a period of time during the first invocation where one of the parallel workers is still running tests, but the rest are out of tests to run, plus test startup/shutdown time.

**Solution**

Invoke pytest once with both test directories.
