### PR TITLE
Update manylinux image to 2_28

### DIFF
--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,7 +1,8 @@
 [tool.cibuildwheel]
 
 build-frontend = "build"
-musllinux-x86_64-image = "musllinux_1_1"  # Change to musllinux_1_2 at some point
+linux.manylinux-x86_64-image = "manylinux_2_28"
+linux.musllinux-x86_64-image = "musllinux_1_1"  # Change to musllinux_1_2 at some point
 
 # Don't build 32-bit wheels or PyPy
 skip = [
@@ -17,7 +18,7 @@ test-skip = "cp38-macosx_arm64"
 build-verbosity = 1
 
 linux.before-all = [
-  "yum install -y llvm-toolset-7.0 || yum -v install -y llvm-toolset-7.0",
+  "yum install -y llvm-toolset || yum -v install -y llvm-toolset",
 ]
 
 before-test = [
@@ -68,8 +69,8 @@ MYPYC_DEBUG_LEVEL = "0"
 # Add llvm paths to environment to eliminate scl usage (like manylinux image does for gcc toolset).
 MYPYC_OPT_LEVEL = "3"
 MYPYC_DEBUG_LEVEL = "0"
-PATH="$PATH:/opt/rh/llvm-toolset-7.0/root/usr/bin"
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rh/llvm-toolset-7.0/root/usr/lib64"
+PATH="$PATH:/opt/rh/llvm-toolset-17.0/root/usr/bin"
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rh/llvm-toolset-17.0/root/usr/lib64"
 CC="clang"
 
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
Update the `manylinux` image from the default `manylinux2014` to `manylinux_2_28`.
The former image reached its EOL a few days ago _(which also caused the temporary build failures)_.

Even though cibuildwheel doesn't plan to update the default anytime soon (see https://github.com/pypa/cibuildwheel/issues/1772#issuecomment-2119982342) we could already start to use the `2_28` image. During the `Repair wheel` step it will get promoted to still support `2_17` / `2014`.

With the new image, it's also slightly faster to build.

https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#acceptable-distros-to-build-wheels
https://mayeut.github.io/manylinux-timeline/

/CC @hauntsaninja What do you think?