### PR TITLE
Let aarch64 build use the same manylinux_2_28 version as default

### DIFF
--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -2,7 +2,9 @@
 
 build-frontend = "build"
 linux.manylinux-x86_64-image = "manylinux_2_28"
+linux.manylinux-aarch64-image = "manylinux_2_28"
 linux.musllinux-x86_64-image = "musllinux_1_1"  # Change to musllinux_1_2 at some point
+linux.musllinux-aarch64-image = "musllinux_1_1"  # Change to musllinux_1_2 at some point
 
 # Don't build 32-bit wheels or PyPy
 skip = [


### PR DESCRIPTION
This PR resolves #83 and is a follow-up to #81 as well as preparation for python/mypy#9688.

Since CentOS 7 becomes EOL and its `llvm-toolset` for **aarch64** is no longer available in the vault repository (see https://vault.centos.org/centos/7/sclo/), let's use the same manylinux_2_28 based on Alma Linux by default for aarch64 as well as x86_64.

To keep using manylinux2014 (CentOS 7), we could try changing the `[tool.cibuildwheel].linux.before-all` to say `yum install -y clang gcc` instead of `yum install -y llvm-toolset` as the manylinux2014 image has been patched to support past-EOL vault repositories for _individual_ packages.

Reference:
- https://github.com/pypa/manylinux#manylinux_2_28-almalinux-8-based
