### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install cibuildwheel and pypyp
         run: |
           pipx install cibuildwheel==2.21.3
-          pipx install pypyp==1
+          pipx install pypyp==1.2.0
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -32,7 +32,7 @@ jobs:
               cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform linux mypy \
               | pyp 'json.dumps({"only": x, "os": "ubuntu-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos mypy \
-              | pyp 'json.dumps({"only": x, "os": "macos-14"})' \
+              | pyp 'json.dumps({"only": x, "os": "macos-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform windows mypy \
               | pyp 'json.dumps({"only": x, "os": "windows-latest"})'
             } | pyp 'json.dumps(list(map(json.loads, lines)))'


### PR DESCRIPTION
Update `pypyp` to `1.2.0` for compatibility with Python 3.11+. Github is in the process of moving the `ubuntu-latest` runners from `ubuntu-22.04` to `ubuntu-24.04` which will also change the default Python version from `3.10` to `3.12` and thus would break the wheel builder without updating pypyp.

Also change `macos-14` back to `macos-latest` as those are the same. This was only needed during the change to M1.
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories