### PR TITLE
Remove unnecessary setuptools install from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Build sdist and wheel
         run: |
           cd mypy
-          pip install --upgrade setuptools build
+          pip install --upgrade build
           python -m build
       - uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
`python -m build` uses isolated build environments. No need to install setuptools manually.