### PR TITLE
Build macos on intel runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,10 @@ jobs:
               | pyp 'json.dumps({"only": x, "os": "ubuntu-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform linux --archs aarch64 mypy \
               | pyp 'json.dumps({"only": x, "os": "ubuntu-24.04-arm"})' \
-              && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos mypy \
+              && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos --archs arm64 mypy \
               | pyp 'json.dumps({"only": x, "os": "macos-latest"})' \
+              && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos --archs x86_64 mypy \
+              | pyp 'json.dumps({"only": x, "os": "macos-26-intel"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform windows mypy \
               | pyp 'json.dumps({"only": x, "os": "windows-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform windows --archs ARM64 mypy \


### PR DESCRIPTION
Followup to https://github.com/mypyc/mypy_mypyc-wheels/pull/117

Split macos jobs to build on their native architectures.
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories