### PR TITLE
Stop building wheels for macOS x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,6 @@ jobs:
               | pyp 'json.dumps({"only": x, "os": "ubuntu-24.04-arm"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos --archs arm64 mypy \
               | pyp 'json.dumps({"only": x, "os": "macos-latest"})' \
-              && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos --archs x86_64 mypy \
-              | pyp 'json.dumps({"only": x, "os": "macos-26-intel"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform windows mypy \
               | pyp 'json.dumps({"only": x, "os": "windows-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform windows --archs ARM64 mypy \

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -8,7 +8,7 @@ linux.musllinux-aarch64-image = "musllinux_1_2"
 
 enable = []
 
-# Don't build musllinux arm64 and 32-bit Windows.
+# Don't build musllinux arm64, 32-bit Windows and macOS x86_64.
 # PyPy and 32-bit Linux are skipped by default.
 # We also skip Pyodide on Python 3.13, because there is no wheel for ast-serialize.
 # To be more precise, although we ship a stable ABI wheel, its platform tag may be different
@@ -17,6 +17,7 @@ enable = []
 # a Rust version that is incompatible with Ruff crates we depend on.
 skip = [
   "*-win32",
+  "*-macosx_x86_64",
   "*-musllinux_aarch64",
   "cp313-pyodide_wasm32",
 ]
@@ -102,20 +103,3 @@ before-test = [
   "pip install -r {project}/mypy/test-requirements.txt",
 ]
 environment = { MYPYC_OPT_LEVEL="3", MYPYC_DEBUG_LEVEL="0", CC="clang" }
-
-# GitHub retired the Intel macOS runners, so x86_64 wheels are now tested under
-# Rosetta on an arm64 host. The Apple clang linker segfaults intermittently under
-# that emulation, which breaks the mypyc run tests (they compile extensions at test
-# time). Since the arm64 job already exercises the full run/compile test suite
-# natively, only run testcheck (no compilation) for x86_64 macOS.
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_x86_64"
-test-command = """ \
-  ( \
-     DIR=$(python -c 'import mypy, os; dn = os.path.dirname; print(dn(dn(mypy.__path__[0])))') \
-     && cp '{project}/mypy/pyproject.toml' '{project}/mypy/conftest.py' $DIR \
-\
-     && MYPY_TEST_DIR=$(python -c 'import mypy.test; print(mypy.test.__path__[0])') \
-     && MYPY_TEST_PREFIX='{project}/mypy' pytest $MYPY_TEST_DIR/testcheck.py \
-   )
-"""


### PR DESCRIPTION
Followup to #117 and #118

The usage for `*-macosx_x86_64` has dropped considerably the last few months to a point that it's now only `0.10%`. As point of comparison, for Python 3.15 (currently in beta, without wheels) it's double that with `0.20%`.

The free tier for Github actions has a limitation of 5 concurrent macos jobs. So dropping 6 jobs per run will speedup total build times.

Users on macOS x86_64 can choose to build wheels locally by installing with
```py
MYPY_USE_MYPYC=1 pip install --no-binary mypy mypy
```